### PR TITLE
Remove upx and change the default config file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ help:
 
 .PHONY: linux
 linux: std-linux-bin
-	upx logspout
+# Comment out upx as it seems causing problems.
+#	upx logspout
 
 .PHONY: std-linux-bin
 std-linux-bin: clean generate
@@ -22,7 +23,8 @@ std-bin: clean generate
 
 .PHONY: bin
 mac: std-bin
-	upx logspout
+# Comment out upx as it seems causing problems.
+#	upx logspout
 
 .PHONY: clean-bin
 clean-bin:

--- a/config/file.go
+++ b/config/file.go
@@ -16,7 +16,7 @@ const (
 func readFile(path string, sizeLimit int64) ([]byte, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("file stat: %s", path))
+		return nil, errors.Wrap(err, "read file")
 	}
 
 	size := fi.Size()

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&ConfigPath, "f", "logspout.json",
+	flag.StringVar(&ConfigPath, "f", "examples/logspout.json",
 		"specify the config file in json format.")
 	flag.StringVar(&LogLevel, "v", "warn",
 		"debug, info, warn, error.")

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 	log.Infof("Starting up Logspout %s", spout.Version())
 	conf, err := config.FromJsonFile(flag.ConfigPath)
 	if err != nil {
-		log.Errorf("Error loading config: %s", err)
+		log.Errorf("Error main: %s", err)
 		return
 	}
 


### PR DESCRIPTION
- remove upx
    - upx seems not compatible with Go 1.11 (?), which causes the program be `killed` all the time.
    - It is also not very useful to strip/compress the program for the time being.

- change the path of the default config file
    - move it into folder `examples`

- other logging improvements