### PR TITLE
Fix a data race of replacers

### DIFF
--- a/output/registry_test.go
+++ b/output/registry_test.go
@@ -1,0 +1,1 @@
+package output

--- a/pattern/offset.go
+++ b/pattern/offset.go
@@ -1,0 +1,3 @@
+package pattern
+
+// TODO: replace based on offset configuration.

--- a/replacer/gen.go
+++ b/replacer/gen.go
@@ -81,6 +81,16 @@ func NewFixedListReplacer(c string, v []string, ci int) Replacer {
 	}
 }
 
+func (fl *FixedListReplacer) Copy() Replacer {
+	n := &FixedListReplacer{
+		method:  fl.method,
+		currIdx: fl.currIdx,
+	}
+	n.valRange = append(n.valRange, fl.valRange...)
+
+	return n
+}
+
 // ReplacedValue returns a new replacement value of fixed-list type.
 func (fl *FixedListReplacer) ReplacedValue(g *rng.GaussianGenerator) (string, error) {
 	var newVal string
@@ -109,6 +119,14 @@ func NewTimeStampReplacer(f string) Replacer {
 	}
 }
 
+func (ts *TimeStampReplacer) Copy() Replacer {
+	n := &TimeStampReplacer{
+		format: ts.format,
+	}
+
+	return n
+}
+
 // ReplacedValue populates a new timestamp with current time.
 func (ts *TimeStampReplacer) ReplacedValue(*rng.GaussianGenerator) (string, error) {
 	return jodaTime.Format(ts.format, time.Now()), nil
@@ -126,6 +144,16 @@ func NewStringReplacer(chars string, min int64, max int64) Replacer {
 		min:   min,
 		max:   max,
 	}
+}
+
+func (s *StringReplacer) Copy() Replacer {
+	n := &StringReplacer{
+		chars: s.chars,
+		min:   s.min,
+		max:   s.max,
+	}
+
+	return n
 }
 
 func (s *StringReplacer) ReplacedValue(g *rng.GaussianGenerator) (string, error) {
@@ -154,6 +182,15 @@ func NewFloatReplacer(min float64, max float64, precision int64) Replacer {
 	}
 }
 
+func (f *FloatReplacer) Copy() Replacer {
+	n := &FloatReplacer{
+		min:       f.min,
+		max:       f.max,
+		precision: f.precision,
+	}
+	return n
+}
+
 func (f *FloatReplacer) ReplacedValue(g *rng.GaussianGenerator) (string, error) {
 	v := f.min + rand.Float64()*(f.max-f.min)
 	s := fmt.Sprintf("%%.%df", f.precision)
@@ -175,6 +212,16 @@ func NewIntegerReplacer(c string, minV int64, maxV int64, cv int64) Replacer {
 		max:     maxV,
 		currVal: cv,
 	}
+}
+
+func (i *IntegerReplacer) Copy() Replacer {
+	n := &IntegerReplacer{
+		method:  i.method,
+		min:     i.min,
+		max:     i.max,
+		currVal: i.currVal,
+	}
+	return n
 }
 
 // ReplacedValue is the main function to populate replacement value of an integer type.
@@ -212,6 +259,15 @@ func NewLooksReal(m string, p map[string]interface{}) Replacer {
 		method: m,
 		opts:   p,
 	}
+}
+
+func (ia *LooksReal) Copy() Replacer {
+	n := &LooksReal{
+		method: ia.method,
+		// opts should be a bunch of read-only data, so it doesn't get deep-copied here.
+		opts: ia.opts,
+	}
+	return n
 }
 
 // ReplacedValue returns random data based on the data type selection.

--- a/replacer/replacer.go
+++ b/replacer/replacer.go
@@ -6,4 +6,17 @@ import "github.com/leesper/go_rng"
 type Replacer interface {
 	// ReplacedValue returns the new replaced value.
 	ReplacedValue(*rng.GaussianGenerator) (string, error)
+
+	// Copy returns a deep copy of the replacer
+	Copy() Replacer
+}
+
+type Replacers map[string]Replacer
+
+func (r Replacers) Copy() Replacers {
+	n := Replacers{}
+	for k, v := range r {
+		n[k] = v.Copy()
+	}
+	return n
 }

--- a/spout/spout.go
+++ b/spout/spout.go
@@ -75,13 +75,16 @@ type Spout struct {
 	// on-the-fly.
 	Output *output.Registry
 
-	// Patterns is a list of regular patterns that define the fields to be repalced
+	// Patterns is a list of regular patterns that define the fields to be replaced
 	// by policies defined in Replacement.
 	Patterns []pattern.Pattern
 
 	// Replacement defines the replacement policies for the fields extracted by
-	// patterns defined in Patterns
-	Replacers map[string]replacer.Replacer
+	// patterns defined in Patterns.
+	//
+	// This field is not concurrent-safe. Each worker should obtain its own copy
+	// of the spout replacers.
+	Replacers replacer.Replacers
 
 	// close is the indicator to close the spout
 	close     chan struct{}

--- a/spout/worker.go
+++ b/spout/worker.go
@@ -44,15 +44,14 @@ func (s *Spout) startWorker(m [][]string, names [][]string, workerID int) {
 	var generatedEvents int
 
 	cTicker := time.NewTicker(time.Second * 1).C
+	workerReplacers := s.Replacers.Copy()
 	for {
 		// The first message of a transaction
-		for k, v := range s.Replacers {
+		for k, v := range workerReplacers {
 			idx := utils.StrIndex(names[evtIdxInTrans], k)
 			if idx == -1 {
 				continue
 			} else if evtIdxInTrans == 0 || utils.StrIndex(s.TransactionID, k) == -1 {
-				// TODO: data race due to multiple workers using/manipulating the same
-				// TODO: replacer object
 				if s, err := v.ReplacedValue(grng); err == nil {
 					matches[evtIdxInTrans][idx] = s
 				}


### PR DESCRIPTION
All the workers read the spout's global replacers map, some of which may be mutated concurrently.
The change makes a local copy for each worker, so that they don't make changes to the spout's replacers. 